### PR TITLE
Delete unused application.properties file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.impressdesigns"
-version = "0.3.0"
+version = "0.4.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-sentry.traces-sample-rate=1.0
-sentry.environment=dev


### PR DESCRIPTION
Was only used for testing Sentry configurations, which are now configured with environmental variables.