### PR TITLE
Limit order numbers to update to orders >300k

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "com.impressdesigns"
-version = "6.0.1"
+version = "6.0.2"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/src/main/kotlin/com/impressdesigns/charlie/Searches.kt
+++ b/src/main/kotlin/com/impressdesigns/charlie/Searches.kt
@@ -66,7 +66,8 @@ fun getOrdersToUpdate(): NumberList {
         val queryText = """
             SELECT ID_Order AS id
             FROM Orders
-            WHERE Orders.date_Modification = ? OR Orders.sts_Invoiced = 0
+            WHERE Orders.ID_Order > 300000 -- Arbitrary limit to reduce runtime and to avoid pulling in invalid data 
+              AND (Orders.date_Modification = ? OR Orders.sts_Invoiced = 0)
     """.trimIndent()
         val query = it.prepareStatement(queryText)
         query.setDate(1, Date(java.util.Date().time))


### PR DESCRIPTION
Arbitrary limit to reduce runtime and to avoid pulling in invalid data.