### PR TITLE
Coalesce null design titles to empty string

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "com.impressdesigns"
-version = "6.0.3"
+version = "6.0.4"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/src/main/kotlin/com/impressdesigns/charlie/Designs.kt
+++ b/src/main/kotlin/com/impressdesigns/charlie/Designs.kt
@@ -38,7 +38,7 @@ fun getDesign(designNumber: Int): Design {
         }
         return Design(
             truncate(result.getFloat("id")).roundToInt(),
-            result.getString("title")
+            result.getString("title") ?: "",
         )
     }
 }


### PR DESCRIPTION
There are three places that null strings can happen

Customer rep/po -- already coalesced to empty string
Part number/description -- line skipped if not present
Design title -- coalesced to empty string in this PR

_Hopefully_ this finally covers all cases.

Fixes CHARLIE-F